### PR TITLE
Fix bulk permissions request body field names

### DIFF
--- a/examples/general/permissions.ts
+++ b/examples/general/permissions.ts
@@ -15,6 +15,6 @@ permissionsClient.getResources()
 
     return permissionsClient.bulkPermissionsUpdate(5142, [
       {resourceId: '3281', resourceType: 'account', accessLevel: 'viewer'},
-      {resourceId: '3809', resourceType: 'inbox', destroy: 'true'}
+      {resourceId: '3809', resourceType: 'inbox', destroy: true}
     ])
   })

--- a/src/__tests__/lib/api/resources/Permissions.test.ts
+++ b/src/__tests__/lib/api/resources/Permissions.test.ts
@@ -63,11 +63,11 @@ describe("lib/api/resources/Permissions: ", () => {
         {
           resourceId: "3809",
           resourceType: "inbox",
-          _destroy: "true",
+          destroy: "true",
         },
       ];
 
-      expect.assertions(2);
+      expect.assertions(3);
 
       mock.onPut(endpoint).reply(200, expectedResponseData);
       const result = await permissionsAPI.bulkPermissionsUpdate(
@@ -76,6 +76,20 @@ describe("lib/api/resources/Permissions: ", () => {
       );
 
       expect(mock.history.put[0].url).toEqual(endpoint);
+      expect(JSON.parse(mock.history.put[0].data)).toEqual({
+        permissions: [
+          {
+            resource_id: "3281",
+            resource_type: "account",
+            access_level: "viewer",
+          },
+          {
+            resource_id: "3809",
+            resource_type: "inbox",
+            _destroy: "true",
+          },
+        ],
+      });
       expect(result).toEqual(expectedResponseData);
     });
 
@@ -93,7 +107,7 @@ describe("lib/api/resources/Permissions: ", () => {
         },
       ];
 
-      expect.assertions(2);
+      expect.assertions(3);
 
       mock.onPut(endpoint).reply(200, expectedResponseData);
       const result = await permissionsAPI.bulkPermissionsUpdate(
@@ -102,6 +116,12 @@ describe("lib/api/resources/Permissions: ", () => {
       );
 
       expect(mock.history.put[0].url).toEqual(endpoint);
+      expect(JSON.parse(mock.history.put[0].data)).toEqual({
+        permissions: [
+          { resource_id: "3281", resource_type: "account" },
+          { resource_id: "3809", resource_type: "inbox" },
+        ],
+      });
       expect(result).toEqual(expectedResponseData);
     });
 

--- a/src/__tests__/lib/api/resources/Permissions.test.ts
+++ b/src/__tests__/lib/api/resources/Permissions.test.ts
@@ -63,7 +63,7 @@ describe("lib/api/resources/Permissions: ", () => {
         {
           resourceId: "3809",
           resourceType: "inbox",
-          destroy: "true",
+          destroy: true,
         },
       ];
 
@@ -86,7 +86,7 @@ describe("lib/api/resources/Permissions: ", () => {
           {
             resource_id: "3809",
             resource_type: "inbox",
-            _destroy: "true",
+            _destroy: true,
           },
         ],
       });

--- a/src/lib/api/resources/Permissions.ts
+++ b/src/lib/api/resources/Permissions.ts
@@ -37,11 +37,9 @@ export default class PermissionsApi {
 
     const flattenPermissionObjects = permissions.map((permission) => ({
       resource_id: permission.resourceId,
-      resourceType: permission.resourceType,
-      ...(permission.accessLevel && { accessLevel: permission.accessLevel }),
-      // @ts-ignore
-      // eslint-disable-next-line no-underscore-dangle
-      ...(permission._destroy && { _destroy: permission.destroy }),
+      resource_type: permission.resourceType,
+      ...(permission.accessLevel && { access_level: permission.accessLevel }),
+      ...(permission.destroy && { _destroy: permission.destroy }),
     }));
     const body = { permissions: flattenPermissionObjects };
 

--- a/src/types/api/permissions.ts
+++ b/src/types/api/permissions.ts
@@ -10,5 +10,5 @@ export type PermissionResourceParams = {
   resourceId: string;
   resourceType: string;
   accessLevel?: string;
-  destroy?: string;
+  destroy?: boolean;
 };


### PR DESCRIPTION

## Motivation

`permissions.bulkPermissionsUpdate` sends a request body the API does not understand: `resourceType`/`accessLevel` are sent camelCase instead of the `resource_type`/`access_level` wire names, and `_destroy` is built from `permission._destroy` (not part of the typed params) while the typed `destroy` field is ignored, so destroy requests are silently dropped. Rails strong params drop the unknown camelCase keys server-side, so the method could not create, update, or destroy any permission.

## Changes

- map `resourceId`/`resourceType`/`accessLevel` params to the `resource_id`/`resource_type`/`access_level` wire names expected by `PUT .../permissions/bulk`
- build `_destroy` from the typed `destroy` param; remove the `@ts-ignore` that was hiding the bug
- type `destroy` as `boolean` to match the OpenAPI `_destroy: boolean` contract (was `string`; a string `"false"` would still destroy the permission server-side, a boolean `false` is safely ignored)
- assert the serialized request body in the bulk permissions tests

## How to test

- [ ] `permissions.bulkPermissionsUpdate(accessId, [{ resourceId, resourceType: "account", accessLevel: "viewer" }])` – the permission is actually created/updated with viewer access (previously the API received unknown camelCase keys and rejected the update)
- [ ] same call with `destroy: true` – the permission is destroyed (previously the `_destroy` flag never reached the API)
- [ ] same call with `destroy: false` – the permission is created/updated, not destroyed
- [ ] `permissions.getResources()` – unchanged

## Companion PRs

- none – standalone fix found while working on MT-23076

Caveat: `destroy` changes from `string` to `boolean` in `PermissionResourceParams`. Since `_destroy` never reached the API before this fix, no caller can depend on the old string behavior.
