### PR TITLE
MT-23488: fix bulk permissions request body field names

### DIFF
--- a/examples/general/permissions.ts
+++ b/examples/general/permissions.ts
@@ -15,6 +15,6 @@ permissionsClient.getResources()
 
     return permissionsClient.bulkPermissionsUpdate(5142, [
       {resourceId: '3281', resourceType: 'account', accessLevel: 'viewer'},
-      {resourceId: '3809', resourceType: 'inbox', destroy: 'true'}
+      {resourceId: '3809', resourceType: 'inbox', destroy: true}
     ])
   })

--- a/src/__tests__/lib/api/resources/Permissions.test.ts
+++ b/src/__tests__/lib/api/resources/Permissions.test.ts
@@ -63,11 +63,11 @@ describe("lib/api/resources/Permissions: ", () => {
         {
           resourceId: "3809",
           resourceType: "inbox",
-          _destroy: "true",
+          destroy: "true",
         },
       ];
 
-      expect.assertions(2);
+      expect.assertions(3);
 
       mock.onPut(endpoint).reply(200, expectedResponseData);
       const result = await permissionsAPI.bulkPermissionsUpdate(
@@ -76,6 +76,20 @@ describe("lib/api/resources/Permissions: ", () => {
       );
 
       expect(mock.history.put[0].url).toEqual(endpoint);
+      expect(JSON.parse(mock.history.put[0].data)).toEqual({
+        permissions: [
+          {
+            resource_id: "3281",
+            resource_type: "account",
+            access_level: "viewer",
+          },
+          {
+            resource_id: "3809",
+            resource_type: "inbox",
+            _destroy: "true",
+          },
+        ],
+      });
       expect(result).toEqual(expectedResponseData);
     });
 
@@ -93,7 +107,7 @@ describe("lib/api/resources/Permissions: ", () => {
         },
       ];
 
-      expect.assertions(2);
+      expect.assertions(3);
 
       mock.onPut(endpoint).reply(200, expectedResponseData);
       const result = await permissionsAPI.bulkPermissionsUpdate(
@@ -102,6 +116,12 @@ describe("lib/api/resources/Permissions: ", () => {
       );
 
       expect(mock.history.put[0].url).toEqual(endpoint);
+      expect(JSON.parse(mock.history.put[0].data)).toEqual({
+        permissions: [
+          { resource_id: "3281", resource_type: "account" },
+          { resource_id: "3809", resource_type: "inbox" },
+        ],
+      });
       expect(result).toEqual(expectedResponseData);
     });
 

--- a/src/__tests__/lib/api/resources/Permissions.test.ts
+++ b/src/__tests__/lib/api/resources/Permissions.test.ts
@@ -63,7 +63,7 @@ describe("lib/api/resources/Permissions: ", () => {
         {
           resourceId: "3809",
           resourceType: "inbox",
-          destroy: "true",
+          destroy: true,
         },
       ];
 
@@ -86,7 +86,7 @@ describe("lib/api/resources/Permissions: ", () => {
           {
             resource_id: "3809",
             resource_type: "inbox",
-            _destroy: "true",
+            _destroy: true,
           },
         ],
       });

--- a/src/lib/api/resources/Permissions.ts
+++ b/src/lib/api/resources/Permissions.ts
@@ -37,11 +37,9 @@ export default class PermissionsApi {
 
     const flattenPermissionObjects = permissions.map((permission) => ({
       resource_id: permission.resourceId,
-      resourceType: permission.resourceType,
-      ...(permission.accessLevel && { accessLevel: permission.accessLevel }),
-      // @ts-ignore
-      // eslint-disable-next-line no-underscore-dangle
-      ...(permission._destroy && { _destroy: permission.destroy }),
+      resource_type: permission.resourceType,
+      ...(permission.accessLevel && { access_level: permission.accessLevel }),
+      ...(permission.destroy && { _destroy: permission.destroy }),
     }));
     const body = { permissions: flattenPermissionObjects };
 

--- a/src/types/api/permissions.ts
+++ b/src/types/api/permissions.ts
@@ -10,5 +10,5 @@ export type PermissionResourceParams = {
   resourceId: string;
   resourceType: string;
   accessLevel?: string;
-  destroy?: string;
+  destroy?: boolean;
 };


### PR DESCRIPTION
## Motivation

MT-23488

`permissions.bulkPermissionsUpdate` didn't work at all. The request body was built with `resourceType` and `accessLevel` keys, but the API expects `resource_type` and `access_level`. Rails strong params drop unknown keys, so the API ignored the update. Destroy was broken too: `_destroy` was only sent when the caller passed an untyped `_destroy` field (hidden behind a `@ts-ignore`), and the typed `destroy` param did nothing.

## Changes

- send `resource_type` and `access_level` instead of the camelCase keys in `PUT .../permissions/bulk`
- build `_destroy` from the typed `destroy` param, drop the `@ts-ignore` that was hiding the bug
- change `destroy` from `string` to `boolean` to match `_destroy: boolean` in the OpenAPI spec. With a string, `destroy: "false"` would still destroy the permission on the server; with a boolean, `false` simply isn't sent
- the bulk permissions tests now check the exact JSON body that goes out

## How to test

- [ ] `permissions.bulkPermissionsUpdate(accessId, [{ resourceId, resourceType: "account", accessLevel: "viewer" }])` – the permission is created/updated with viewer access. Before the fix the API dropped the camelCase keys and nothing changed
- [ ] the same call with `destroy: true` – the permission is destroyed. Before the fix the destroy flag never reached the API
- [ ] the same call with `destroy: false` – the permission is created/updated, not destroyed
- [ ] `permissions.getResources()` – still works as before

Caveat: `destroy` in `PermissionResourceParams` changes from `string` to `boolean`. Nobody can depend on the old type – `_destroy` never reached the API before this fix.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bulk permission updates to send deletion flags as boolean values.
  * Improved request serialization to use the expected API field names.
  * Updated permission parameter validation to accept optional boolean deletion flags.

* **Tests**
  * Added coverage verifying serialized payloads for both permission update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
